### PR TITLE
Added tests, Fixed microseconds in ToSql implementations

### DIFF
--- a/postgres-types/src/jiff_01.rs
+++ b/postgres-types/src/jiff_01.rs
@@ -1,8 +1,7 @@
 use bytes::BytesMut;
 use jiff_01::{
     civil::{Date, DateTime, Time},
-    tz::TimeZone,
-    Span, Timestamp, Zoned,
+    Span, Timestamp,
 };
 use postgres_protocol::types;
 use std::error::Error;

--- a/tokio-postgres/src/keepalive.rs
+++ b/tokio-postgres/src/keepalive.rs
@@ -12,12 +12,18 @@ impl From<&KeepaliveConfig> for TcpKeepalive {
     fn from(keepalive_config: &KeepaliveConfig) -> Self {
         let mut tcp_keepalive = Self::new().with_time(keepalive_config.idle);
 
-        #[cfg(not(any(target_os = "redox", target_os = "solaris", target_os = "openbsd")))]
+        #[cfg(not(any(
+            target_os = "aix",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "openbsd"
+        )))]
         if let Some(interval) = keepalive_config.interval {
             tcp_keepalive = tcp_keepalive.with_interval(interval);
         }
 
         #[cfg(not(any(
+            target_os = "aix",
             target_os = "redox",
             target_os = "solaris",
             target_os = "windows",

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -89,10 +89,15 @@ where
 
     loop {
         match responses.next().await? {
-            Message::ParseComplete
-            | Message::BindComplete
-            | Message::ParameterDescription(_)
-            | Message::NoData => {}
+            Message::ParseComplete | Message::BindComplete | Message::ParameterDescription(_) => {}
+            Message::NoData => {
+                return Ok(RowStream {
+                    statement: Statement::unnamed(vec![], vec![]),
+                    responses,
+                    rows_affected: None,
+                    _p: PhantomPinned,
+                });
+            }
             Message::RowDescription(row_description) => {
                 let mut columns: Vec<Column> = vec![];
                 let mut it = row_description.fields();

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -997,6 +997,13 @@ async fn query_typed_no_transaction() {
     assert_eq!(second_row.get::<_, i32>(1), 40);
     assert_eq!(second_row.get::<_, &str>(2), "literal");
     assert_eq!(second_row.get::<_, i32>(3), 5);
+
+    // Test for UPDATE that returns no data
+    let updated_rows = client
+        .query_typed("UPDATE foo set age = 33", &[])
+        .await
+        .unwrap();
+    assert_eq!(updated_rows.len(), 0);
 }
 
 #[tokio::test]
@@ -1064,4 +1071,11 @@ async fn query_typed_with_transaction() {
     assert_eq!(second_row.get::<_, i32>(1), 40);
     assert_eq!(second_row.get::<_, &str>(2), "literal");
     assert_eq!(second_row.get::<_, i32>(3), 5);
+
+    // Test for UPDATE that returns no data
+    let updated_rows = transaction
+        .query_typed("UPDATE foo set age = 33", &[])
+        .await
+        .unwrap();
+    assert_eq!(updated_rows.len(), 0);
 }

--- a/tokio-postgres/tests/test/types/jiff_01.rs
+++ b/tokio-postgres/tests/test/types/jiff_01.rs
@@ -1,0 +1,176 @@
+use jiff_01::{civil::Date, civil::DateTime, civil::Time, Timestamp};
+use std::fmt;
+use tokio_postgres::types::{self, FromSqlOwned};
+use tokio_postgres::Client;
+
+use crate::connect;
+use crate::types::test_type;
+
+#[tokio::test]
+async fn test_civil_datetime_params() {
+    fn make_check(time: &str) -> (Option<DateTime>, &str) {
+        (
+            Some(DateTime::strptime("'%Y-%m-%d %H:%M:%S.%f'", time).unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000'"),
+            make_check("'1965-09-25 11:19:33.100314000'"),
+            make_check("'2010-02-09 23:11:45.120200000'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_with_special_civil_datetime_params() {
+    fn make_check(time: &str) -> (types::Timestamp<DateTime>, &str) {
+        (
+            types::Timestamp::Value(DateTime::strptime("'%Y-%m-%d %H:%M:%S.%f'", time).unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000'"),
+            make_check("'1965-09-25 11:19:33.100314000'"),
+            make_check("'2010-02-09 23:11:45.120200000'"),
+            (types::Timestamp::PosInfinity, "'infinity'"),
+            (types::Timestamp::NegInfinity, "'-infinity'"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_timestamp_params() {
+    fn make_check(time: &str) -> (Option<Timestamp>, &str) {
+        (
+            Some(Timestamp::strptime("'%Y-%m-%d %H:%M:%S.%f %z'", time).unwrap()),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP WITH TIME ZONE",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000 +0000'"),
+            make_check("'1965-09-25 11:19:33.100314000 +0000'"),
+            make_check("'2010-02-09 23:11:45.120200000 +0000'"),
+            make_check("'2010-11-20 17:11:45.120200000 +0500'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_with_special_timestamp_params() {
+    fn make_check(time: &str) -> (types::Timestamp<Timestamp>, &str) {
+        (
+            types::Timestamp::Value(
+                Timestamp::strptime("'%Y-%m-%d %H:%M:%S.%f %z'", time).unwrap(),
+            ),
+            time,
+        )
+    }
+    test_type(
+        "TIMESTAMP WITH TIME ZONE",
+        &[
+            make_check("'1970-01-01 00:00:00.010000000 +0000'"),
+            make_check("'1965-09-25 11:19:33.100314000 +0000'"),
+            make_check("'2010-02-09 23:11:45.120200000 +0000'"),
+            (types::Timestamp::PosInfinity, "'infinity'"),
+            (types::Timestamp::NegInfinity, "'-infinity'"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_date_params() {
+    fn make_check(time: &str) -> (Option<Date>, &str) {
+        (Some(Date::strptime("'%Y-%m-%d'", time).unwrap()), time)
+    }
+    test_type(
+        "DATE",
+        &[
+            make_check("'1970-01-01'"),
+            make_check("'1965-09-25'"),
+            make_check("'2010-02-09'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_with_special_date_params() {
+    fn make_check(date: &str) -> (types::Date<Date>, &str) {
+        (
+            types::Date::Value(Date::strptime("'%Y-%m-%d'", date).unwrap()),
+            date,
+        )
+    }
+    test_type(
+        "DATE",
+        &[
+            make_check("'1970-01-01'"),
+            make_check("'1965-09-25'"),
+            make_check("'2010-02-09'"),
+            (types::Date::PosInfinity, "'infinity'"),
+            (types::Date::NegInfinity, "'-infinity'"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_time_params() {
+    fn make_check(time: &str) -> (Option<Time>, &str) {
+        (Some(Time::strptime("'%H:%M:%S.%f'", time).unwrap()), time)
+    }
+    test_type(
+        "TIME",
+        &[
+            make_check("'00:00:00.010000000'"),
+            make_check("'11:19:33.100314000'"),
+            make_check("'23:11:45.120200000'"),
+            (None, "NULL"),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_special_params_without_wrapper() {
+    async fn assert_overflows<T>(client: &mut Client, val: &str, sql_type: &str)
+    where
+        T: FromSqlOwned + fmt::Debug,
+    {
+        let err = client
+            .query_one(&*format!("SELECT {}::{}", val, sql_type), &[])
+            .await
+            .unwrap()
+            .try_get::<_, T>(0)
+            .unwrap_err();
+        // Jiff's Error type has limited introspection so I am being dirty here
+        let display_string = format!("{}", err);
+        assert!(display_string.contains("is not in the required range of"));
+    }
+
+    let mut client = connect("user=postgres").await;
+
+    assert_overflows::<Timestamp>(&mut client, "'-infinity'", "timestamptz").await;
+    assert_overflows::<Timestamp>(&mut client, "'infinity'", "timestamptz").await;
+
+    assert_overflows::<DateTime>(&mut client, "'-infinity'", "timestamp").await;
+    assert_overflows::<DateTime>(&mut client, "'infinity'", "timestamp").await;
+
+    assert_overflows::<Date>(&mut client, "'-infinity'", "date").await;
+    assert_overflows::<Date>(&mut client, "'infinity'", "date").await;
+}

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -23,6 +23,8 @@ mod eui48_1;
 mod geo_types_06;
 #[cfg(feature = "with-geo-types-0_7")]
 mod geo_types_07;
+#[cfg(feature = "with-jiff-0_1")]
+mod jiff_01;
 #[cfg(feature = "with-serde_json-1")]
 mod serde_json_1;
 #[cfg(feature = "with-smol_str-01")]


### PR DESCRIPTION
I took a stab at making some tests as per https://github.com/sfackler/rust-postgres/pull/1164#issuecomment-2246629958. 


Tests:

Added tests in /tokio-postgres/tests/test/types/jiff_01.rs
for civil::Date, civil::DateTime, civil::Time, Timestamp


Fixes: 

- Changed Span::new().microseconds(x) to Span::new().try_microseconds(x) in the FromSql implementations. The former panics, the latter returns a Result. 

- There was a misuse of Span when trying to get the number of microseconds since the epoch in the ToSql implementations. 

For example, the following code: 
```
let epoch = DateTime::constant(2000, 1, 1, 0, 0, 0, 0);
let datetime =  DateTime::strptime("'%Y-%m-%d %H:%M:%S.%f'", "'1970-01-01 00:00:00.010000000’”)?;
datetime.since(epoch)?.get_microseconds()
```
returns the value of the field microseconds in the span, not the total number of microseconds if you convert all of the days, hours, minutes, etc to microseconds and sum them. 

What we want is:
```
datetime.since(epoch)?.total(Unit::Microsecond)? as i64
```

Aside: 
——
Fwiw @BurntSushi, it’s clear to me now and the docs were helpful once I knew to look, but initially I found this confusing. 
This is a common operation so might I suggest including an example of getting the total seconds of a Span, or similar, in the Usage section of the Readme. 

I would also have a preference for adding methods to Span for something like .total_microseconds(), .total_seconds(), etc. 

Maybe I’m showing my ignorance of standards/common expectations here, but at a glance I might also opt for .set_microseconds(x) over .microseconds(x) just to disambiguate it. If one were to not be prepended, I would actually have defaulted to having the getter be .microseconds() rather than the setter. Though I do see what you’re doing with .try_microseconds(). I personally would probably never use the panic version of the methods but can understand others preferring it. I wonder if people might naively not realize the non-try version panics. 

As a final commentary (sorry), I would personally rather have the fields be public and get/set them directly. I see what you’re doing with the min and max ranges (which is nice!) so perhaps that just wouldn’t be clean enough to do. But generally I’d rather do span.microseconds = x, span.microseconds = x.into(), or even span.microseconds = SpanMicroseconds::try_new(x)?, and then be able to get with a simple span.microseconds. Probably my weakest suggestion here given I have a bias against getters and setters unless absolutely necessary. Having set_, get_, and total_ would probably be sufficient to make things very clear for the user. 

Separately, a method or other mechanism for checking what type of Error is returned would be helpful. One of my tests uses a very dirty method of
```
assert!(display_string.contains("is not in the required range of"));
```

(I’m enjoying the library so far and appreciate the evident thought and work you put into this. Just my 2c for whatever it’s worth while the library is still being developed). 
——